### PR TITLE
feat: supporting onPurge callback for purging notification

### DIFF
--- a/src/pacer.ts
+++ b/src/pacer.ts
@@ -4,16 +4,20 @@ import { delay } from './delay';
 
 export class Pacer<T> {
 	private purgeTask: PromiseLike<void> | undefined;
-	private toPurge = new Fifo<{ purgeTime: number; payload: T }>();
+	private toPurge = new Fifo<{
+		purgeTime: number;
+		payload: T;
+		callback?: (payload: T) => void;
+	}>();
 	private pace: (payload: T) => number;
 
 	constructor(pace: Ttl, private run: (payload: T) => any) {
 		this.pace = typeof pace === 'number' ? () => pace : pace;
 	}
 
-	schedulePurge(payload: T) {
+	schedulePurge(payload: T, callback?: (payload: T) => void) {
 		const purgeTime = Date.now() + this.pace(payload);
-		this.toPurge.push({ purgeTime, payload });
+		this.toPurge.push({ purgeTime, payload, callback });
 		if (!this.purgeTask) {
 			this.purgeTask = this.wait();
 		}
@@ -27,6 +31,9 @@ export class Pacer<T> {
 				await delay(waiting);
 			}
 			this.run(current.payload);
+			if (current.callback) {
+				current.callback(current.payload);
+			}
 			return this.wait();
 		} else {
 			this.purgeTask = undefined;

--- a/src/remembered.ts
+++ b/src/remembered.ts
@@ -30,6 +30,7 @@ export class Remembered {
 		key: string,
 		callback: () => PromiseLike<T>,
 		noCacheIf?: (result: T) => boolean,
+		onPurge?: (key: string) => void,
 	): PromiseLike<T> {
 		const cached = this.map.get(key);
 		if (cached) {
@@ -38,7 +39,7 @@ export class Remembered {
 		}
 		const value = this.loadValue(key, callback, noCacheIf);
 		this.map.set(key, value);
-		this.pacer?.schedulePurge(key);
+		this.pacer?.schedulePurge(key, onPurge);
 
 		return value;
 	}

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -216,5 +216,22 @@ describe(Remembered.name, () => {
 			expect(result3).toBe(2);
 			expect(result4).toBe(3);
 		});
+
+		it('should call the onPurge callback when purge happens', async () => {
+			let count = 0;
+			let ttl = 100;
+			const getter = jest.fn().mockImplementation(async () => ++count);
+			target = new Remembered({ ttl: () => ttl });
+			const key = 'key value';
+			const onPurge = jest.fn();
+
+			const result = await target.get(key, getter, undefined, onPurge);
+			await delay(100);
+			ttl = 40;
+
+			expectCallsLike(getter, []);
+			expectCallsLike(onPurge, [key]);
+			expect(result).toBe(1);
+		});
 	});
 });


### PR DESCRIPTION
onPurge callback will be called when the purge for the given function happens. This is useful if you want to take some automatic action as soon as the cache is purged, like renovating it, for example