### PR TITLE
Adding nonBlocking option

### DIFF
--- a/src/dont-wait.ts
+++ b/src/dont-wait.ts
@@ -1,0 +1,12 @@
+export function dontWait(
+	callback: () => PromiseLike<unknown>,
+	errorCallback?: (err: Error) => void,
+): void {
+	process.nextTick(async () => {
+		try {
+			await callback();
+		} catch (error) {
+			errorCallback?.(error as Error);
+		}
+	});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './dont-wait';
 export * from './remembered';
 export * from './remembered-config';

--- a/src/pacer.ts
+++ b/src/pacer.ts
@@ -4,16 +4,20 @@ import { delay } from './delay';
 
 export class Pacer<T> {
 	private purgeTask: PromiseLike<void> | undefined;
-	private toPurge = new Fifo<{ purgeTime: number; payload: T }>();
+	private toPurge = new Fifo<{
+		purgeTime: number;
+		payload: T;
+		callback?: (payload: T) => void;
+	}>();
 	private pace: (payload: T) => number;
 
 	constructor(pace: Ttl, private run: (payload: T) => any) {
 		this.pace = typeof pace === 'number' ? () => pace : pace;
 	}
 
-	schedulePurge(payload: T) {
+	schedulePurge(payload: T, callback?: (payload: T) => void) {
 		const purgeTime = Date.now() + this.pace(payload);
-		this.toPurge.push({ purgeTime, payload });
+		this.toPurge.push({ purgeTime, payload, callback });
 		if (!this.purgeTask) {
 			this.purgeTask = this.wait();
 		}
@@ -27,6 +31,9 @@ export class Pacer<T> {
 				await delay(waiting);
 			}
 			this.run(current.payload);
+			if (current.callback) {
+				current.callback(current.payload);
+			}
 			return this.wait();
 		} else {
 			this.purgeTask = undefined;

--- a/src/remembered-config.ts
+++ b/src/remembered-config.ts
@@ -2,5 +2,9 @@ export type Ttl = number | (<T>(request: T) => number);
 
 export interface RememberedConfig {
 	ttl: Ttl;
+	/**
+	 * Always keep a persistent last result for the cache when there is one, so the cache can be updated in background
+	 */
+	nonBlocking?: boolean;
 	onReused?: (key: string) => void;
 }

--- a/src/remembered.ts
+++ b/src/remembered.ts
@@ -30,6 +30,7 @@ export class Remembered {
 		key: string,
 		callback: () => PromiseLike<T>,
 		noCacheIf?: (result: T) => boolean,
+		onPurge?: (key: string) => void,
 	): PromiseLike<T> {
 		const cached = this.map.get(key);
 		if (cached) {
@@ -38,7 +39,7 @@ export class Remembered {
 		}
 		const value = this.loadValue(key, callback, noCacheIf);
 		this.map.set(key, value);
-		this.pacer?.schedulePurge(key);
+		this.pacer?.schedulePurge(key, onPurge);
 
 		return value;
 	}

--- a/test/unit/dont-wait.spec.ts
+++ b/test/unit/dont-wait.spec.ts
@@ -1,0 +1,39 @@
+import { promisify } from 'util';
+import { dontWait } from '../../src/dont-wait';
+import { expectCallsLike } from './setup';
+const wait = promisify(setTimeout);
+
+describe(dontWait.name, () => {
+	let callback: jest.SpyInstance;
+	let errorCallback: jest.SpyInstance;
+
+	beforeEach(() => {
+		callback = jest.fn().mockResolvedValue('something');
+		errorCallback = jest.fn();
+	});
+
+	it('should execute callback on the next tick', async () => {
+		dontWait(callback as any);
+
+		expectCallsLike(callback);
+
+		await wait(1);
+
+		expectCallsLike(callback, []);
+	});
+
+	it('should execute dontWait() error callback on the next tick', async () => {
+		const error = new Error();
+		callback.mockRejectedValue(error);
+
+		dontWait(callback as any, errorCallback as any);
+
+		expectCallsLike(callback);
+		expectCallsLike(errorCallback);
+
+		await wait(1);
+
+		expectCallsLike(callback, []);
+		expectCallsLike(errorCallback, [error]);
+	});
+});

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -139,6 +139,29 @@ describe(Remembered.name, () => {
 			expect(result2).toBe(1);
 			expect(result3).toBe(2);
 		});
+
+		it('should always get from cache when there is a last result, event an expired one when nonBlocking is true', async () => {
+			const target2 = new Remembered({
+				ttl: 2,
+				nonBlocking: true,
+			});
+			let i = 0;
+			const callback = jest.fn().mockImplementation(() => i++);
+
+			const result1 = await target2.get('a', callback);
+			await delay(3);
+			const result2 = await target2.get('a', callback);
+
+			expect(result1).toBe(result2);
+			expectCallsLike(callback, []);
+			await delay(1);
+			expectCallsLike(callback, [], []);
+			const result3 = await target2.get('a', callback);
+			expect(result3).toBe(1);
+			expectCallsLike(callback, [], []);
+			await delay(1);
+			expectCallsLike(callback, [], []);
+		});
 	});
 
 	describe(methods.wrap, () => {

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -140,7 +140,7 @@ describe(Remembered.name, () => {
 			expect(result3).toBe(2);
 		});
 
-		it('should always get from cache when there is a last result, event an expired one when nonBlocking is true', async () => {
+		it('should always get from cache when there is a last result, even an expired one when nonBlocking is true', async () => {
 			const target2 = new Remembered({
 				ttl: 2,
 				nonBlocking: true,


### PR DESCRIPTION
The nonBlocking option makes remembered always keep a persistent last result for the cache when there is one, so the cache can be updated in the background