### PR TITLE
feat: adding getSync for nonBlocking instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,6 +1100,8 @@
     },
     "@types/glob": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -1151,6 +1153,8 @@
     },
     "@types/json-schema": {
       "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/json5": {
@@ -1161,10 +1165,14 @@
     },
     "@types/minimatch": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
     "@types/node": {
@@ -1175,6 +1183,8 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
     "@types/prettier": {
@@ -1826,7 +1836,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "console-control-strings": {
@@ -2307,10 +2317,14 @@
     },
     "eslint-rule-composer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -2319,6 +2333,8 @@
     },
     "eslint-utils": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -2334,6 +2350,8 @@
     },
     "eslint-visitor-keys": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
@@ -4617,6 +4635,8 @@
     },
     "mime-types": {
       "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "dev": true,
       "requires": {
         "mime-db": "1.46.0"
@@ -4635,9 +4655,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5945,8 +5965,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha512-wFUFA5bg5dviipbQQ32yOQhl6gcJaJXiHE7dvR8VYPG97+J/GNC5FKGepKdEDUFeXRzDxPF1X/Btc8L+v7oqIQ==",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/src/remembered.ts
+++ b/src/remembered.ts
@@ -44,6 +44,19 @@ export class Remembered {
 		return this.blockingGet(key, callback, noCacheIf);
 	}
 
+	getSync<T>(
+		key: string,
+		callback: () => PromiseLike<T>,
+		noCacheIf?: (result: T) => boolean,
+	): T | undefined {
+		if (!this.config.nonBlocking) {
+			throw new Error('getSync is only available for nonBlocking instances');
+		}
+		dontWait(() => this.blockingGet(key, callback, noCacheIf));
+
+		return this.nonBlockingMap.get(key);
+	}
+
 	blockingGet<T>(
 		key: string,
 		callback: () => PromiseLike<T>,

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -163,6 +163,67 @@ describe(Remembered.name, () => {
 		});
 	});
 
+	describe(methods.getSync, () => {
+		it('should return cache result when it exists', async () => {
+			const target2 = new Remembered({
+				ttl: 2,
+				nonBlocking: true,
+			});
+			let i = 0;
+			const callback = jest.fn().mockImplementation(() => i++);
+
+			const result1 = await target2.get('a', callback);
+			await delay(3);
+			const result2 = target2.getSync('a', callback);
+
+			expect(result1).toBe(result2);
+			expectCallsLike(callback, []);
+			await delay(1);
+			expectCallsLike(callback, [], []);
+			const result3 = await target2.get('a', callback);
+			expect(result3).toBe(1);
+			expectCallsLike(callback, [], []);
+			await delay(1);
+			expectCallsLike(callback, [], []);
+		});
+
+		it('should return undefined when no cache exists, but return something after it is warmed up', async () => {
+			const target2 = new Remembered({
+				ttl: 2,
+				nonBlocking: true,
+			});
+			let i = 0;
+			const callback = jest.fn().mockImplementation(() => i++);
+
+			const result1 = target2.getSync('a', callback);
+
+			expect(result1).toBeUndefined();
+			expectCallsLike(callback);
+			await delay(1);
+			expectCallsLike(callback, []);
+			const result2 = target2.getSync('a', callback);
+			expect(result2).toBe(0);
+		});
+
+		it('should throw an error when nonBlocking is false', async () => {
+			const target2 = new Remembered({
+				ttl: 2,
+				nonBlocking: false,
+			});
+			let i = 0;
+			const callback = jest.fn().mockImplementation(() => i++);
+			let err: any;
+
+			try {
+				target2.getSync('a', callback);
+			} catch (error) {
+				err = error;
+			}
+
+			expect(err).toBeInstanceOf(Error);
+		});
+	});
+
 	describe(methods.wrap, () => {
 		it('should return a rememberable callback', async () => {
 			let count = 0;


### PR DESCRIPTION
getSync will allow the use of a synchronous cache that updates in the background.

If getSync is called before the cache for the informed key is warmed up, it will return undefined, so it is important to warm up your values before starting to use it, or be aware of it when calling it