### PR TITLE
feat: implement getTll from ttlFunction in constructor configuration

### DIFF
--- a/src/remembered-config.ts
+++ b/src/remembered-config.ts
@@ -1,7 +1,14 @@
-export type Ttl = number | (<T>(request: T) => number);
+export type TtlFunction<TResponse = unknown, TKey = string> = (
+	key: TKey,
+	response?: TResponse,
+) => number;
 
-export interface RememberedConfig {
-	ttl: Ttl;
+export type Ttl<TResponse = unknown, TKey = string> =
+	| number
+	| TtlFunction<TResponse, TKey>;
+
+export interface RememberedConfig<TResponse = unknown, TKey = string> {
+	ttl: Ttl<TResponse, TKey>;
 	/**
 	 * Always keep a persistent last result for the cache when there is one, so the cache can be updated in the background
 	 */


### PR DESCRIPTION
Implement function to getTll from params in method .get or .getSync, or from config.tll in contructor configuration.
Improvement in the typing of methods and classes.